### PR TITLE
Adding per gpu --gpu-threads support

### DIFF
--- a/driver-opencl.c
+++ b/driver-opencl.c
@@ -278,6 +278,36 @@ char *set_gpu_map(char *arg)
 	return NULL;
 }
 
+char *set_gpu_threads(char *arg)
+{
+	int i, val = 1, device = 0;
+	char *nextptr;
+
+	nextptr = strtok(arg, ",");
+	if (nextptr == NULL)
+		return "Invalid parameters for set_gpu_threads";
+	val = atoi(nextptr);
+	if (val < 1 || val > 10)
+		return "Invalid value passed to set_gpu_threads";
+
+	gpus[device++].threads = val;
+
+	while ((nextptr = strtok(NULL, ",")) != NULL) {
+		val = atoi(nextptr);
+		if (val < 1 || val > 10)
+			return "Invalid value passed to set_gpu_threads";
+
+		gpus[device++].threads = val;
+	}
+	if (device == 1) {
+		for (i = device; i < MAX_GPUDEVICES; i++)
+			gpus[i].threads = gpus[0].threads;
+	}
+
+	return NULL;
+}
+
+
 char *set_gpu_engine(char *arg)
 {
 	int i, val1 = 0, val2 = 0, device = 0;
@@ -1284,7 +1314,12 @@ static void opencl_detect(bool hotplug)
 		cgpu->deven = DEV_ENABLED;
 		cgpu->drv = &opencl_drv;
 		cgpu->device_id = i;
+#ifndef HAVE_ADL
 		cgpu->threads = opt_g_threads;
+#else
+		if (cgpu->threads < 1)
+			cgpu->threads = 1;
+#endif
 		cgpu->virtual_gpu = i;
 		add_cgpu(cgpu);
 	}

--- a/driver-opencl.c
+++ b/driver-opencl.c
@@ -1,4 +1,4 @@
-/*
+	/*
  * Copyright 2011-2012 Con Kolivas
  * Copyright 2011-2012 Luke Dashjr
  * Copyright 2010 Jeff Garzik
@@ -1361,7 +1361,7 @@ static void get_opencl_statline_before(char *buf, size_t bufsiz, struct cgpu_inf
 
 static void get_opencl_statline(char *buf, size_t bufsiz, struct cgpu_info *gpu)
 {
-	tailsprintf(buf, bufsiz, " I:%2d", gpu->intensity);
+	tailsprintf(buf, bufsiz, " T:%d I:%2d", gpu->threads, gpu->intensity);
 }
 
 struct opencl_thread_data {

--- a/driver-opencl.h
+++ b/driver-opencl.h
@@ -7,6 +7,7 @@
 extern void print_ndevs(int *ndevs);
 extern void *reinit_gpu(void *userdata);
 extern char *set_gpu_map(char *arg);
+extern char *set_gpu_threads(char *arg);
 extern char *set_gpu_engine(char *arg);
 extern char *set_gpu_fan(char *arg);
 extern char *set_gpu_memclock(char *arg);

--- a/vertminer.c
+++ b/vertminer.c
@@ -1175,12 +1175,14 @@ static struct opt_table opt_config_table[] = {
 	OPT_WITH_ARG("--gpu-platform",
 		     set_int_0_to_9999, opt_show_intval, &opt_platform_id,
 		     "Select OpenCL platform ID to use for GPU mining"),
-
+#ifndef HAVE_ADL
 	OPT_WITH_ARG("--gpu-threads|-g",
 		     set_int_1_to_10, opt_show_intval, &opt_g_threads,
 		     "Number of threads per GPU (1 - 10)"),
-
-#ifdef HAVE_ADL
+#else
+ 	OPT_WITH_ARG("--gpu-threads|-g",
+ 		     set_gpu_threads, NULL, NULL,
+ 		     "Number of threads per GPU - one value or comma separated list (e.g. 1,2,1)"),
 	OPT_WITH_ARG("--gpu-engine",
 		     set_gpu_engine, NULL, NULL,
 		     "GPU engine (over)clock range in Mhz - one value, range and/or comma separated list (e.g. 850-900,900,750-850)"),


### PR DESCRIPTION
I have a 2 \* R9 280X and a 7850 Card in the same rig.. So I've needed to use -g2 in the first 2 and -g1 in the last one.. Cgminer had a bug with this parameter that only allowed a global -g parameter (same for all cards)

So, I've modified vertminer to add the changes from a cgminer 3.7.2 fork. Here is the original diff

https://github.com/Kalroth/cgminer-3.7.2-kalroth/commit/5a4d75b3e8ac7feeb1c9dceb8ca4615dacda4178

I've builded this in Centos 6.5 and works perfectly. So, this is my contribution.
![vertminer](https://f.cloud.github.com/assets/333676/2479712/b5ab7a02-b0a0-11e3-9f09-0dd3f720805a.png)
